### PR TITLE
Return HTTP status 400 if missing JWT

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -254,11 +254,11 @@ func (config Config) ToMiddleware() (echo.MiddlewareFunc, error) {
 				return tmpErr
 			}
 
-			message := "invalid or expired jwt"
 			if lastTokenErr == nil {
-				message = "missing or malformed jwt"
+				return echo.NewHTTPError(http.StatusBadRequest, "missing or malformed jwt").SetInternal(err)
 			}
-			return echo.NewHTTPError(http.StatusUnauthorized, message).SetInternal(err)
+
+			return echo.NewHTTPError(http.StatusUnauthorized, "invalid or expired jwt").SetInternal(err)
 		}
 	}, nil
 }

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -156,14 +156,14 @@ func TestJWT_combinations(t *testing.T) {
 			config: Config{
 				SigningKey: validKey,
 			},
-			expectError: "code=401, message=missing or malformed jwt, internal=invalid value in request header",
+			expectError: "code=400, message=missing or malformed jwt, internal=invalid value in request header",
 		},
 		{
 			name: "Empty header auth field",
 			config: Config{
 				SigningKey: validKey,
 			},
-			expectError: "code=401, message=missing or malformed jwt, internal=invalid value in request header",
+			expectError: "code=400, message=missing or malformed jwt, internal=invalid value in request header",
 		},
 		{
 			name: "Valid query method",
@@ -180,7 +180,7 @@ func TestJWT_combinations(t *testing.T) {
 				TokenLookup: "query:jwt",
 			},
 			reqURL:      "/?a=b&jwtxyz=" + token,
-			expectError: "code=401, message=missing or malformed jwt, internal=missing value in the query string",
+			expectError: "code=400, message=missing or malformed jwt, internal=missing value in the query string",
 		},
 		{
 			name: "Invalid query param value",
@@ -198,7 +198,7 @@ func TestJWT_combinations(t *testing.T) {
 				TokenLookup: "query:jwt",
 			},
 			reqURL:      "/?a=b",
-			expectError: "code=401, message=missing or malformed jwt, internal=missing value in the query string",
+			expectError: "code=400, message=missing or malformed jwt, internal=missing value in the query string",
 		},
 		{
 			config: Config{
@@ -239,7 +239,7 @@ func TestJWT_combinations(t *testing.T) {
 				SigningKey:  validKey,
 				TokenLookup: "cookie:jwt",
 			},
-			expectError: "code=401, message=missing or malformed jwt, internal=missing value in cookies",
+			expectError: "code=400, message=missing or malformed jwt, internal=missing value in cookies",
 		},
 		{
 			name: "Valid form method",
@@ -264,7 +264,7 @@ func TestJWT_combinations(t *testing.T) {
 				SigningKey:  validKey,
 				TokenLookup: "form:jwt",
 			},
-			expectError: "code=401, message=missing or malformed jwt, internal=missing value in the form",
+			expectError: "code=400, message=missing or malformed jwt, internal=missing value in the form",
 		},
 	}
 


### PR DESCRIPTION
## Fixes

https://github.com/labstack/echo-jwt/blob/6944ffef14c19d496a831b17e518b6f3e0b7c88f/jwt.go#L159-L161

https://echo.labstack.com/docs/middleware/jwt

Should return HTTP status 400 if missing JWT as documented.