### PR TITLE
Update whitespace output example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ curl -v -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiO
 
 Output should be
 ```bash
-*   Trying 127.0.0.1:8080...
+* Trying 127.0.0.1:8080...
 * Connected to localhost (127.0.0.1) port 8080 (#0)
 > GET / HTTP/1.1
 > Host: localhost:8080


### PR DESCRIPTION
**Hello, please check out this promotion**

I encountered an open source called echo-jwt while browsing several open sources to process jwt-related logic, and while referencing the document, there was a space in the first line of the output example.

However, I'm not sure if it was intentionally spaced, accidentally spaced, or accidentally spaced. If it's a mistake, please merge this PR!

Thank you