### PR TITLE
Fix bug where config.ContinueOnIgnoredError does not take effect when…

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -246,11 +246,11 @@ func (config Config) ToMiddleware() (echo.MiddlewareFunc, error) {
 			} else if lastExtractorErr != nil {
 				err = &TokenExtractionError{Err: lastExtractorErr}
 			}
+			if config.ContinueOnIgnoredError {
+				return next(c)
+			}
 			if config.ErrorHandler != nil {
 				tmpErr := config.ErrorHandler(c, err)
-				if config.ContinueOnIgnoredError && tmpErr == nil {
-					return next(c)
-				}
 				return tmpErr
 			}
 


### PR DESCRIPTION
… set to true

[https://github.com/labstack/echo-jwt/blob/2fe4a09e5ba3530b701397c0f42d5003958def3f/jwt.go#L251C1-L253C6](https://github.com/labstack/echo-jwt/blob/2fe4a09e5ba3530b701397c0f42d5003958def3f/jwt.go#L251C1-L253C6)
In the current version, when config.ContinueOnIgnoredError is set to true, the code block:
```
    if config.ContinueOnIgnoredError && tmpErr == nil {
	    return next(c)
    }
```
is unreachable.

