### PR TITLE
Add note to SigningMethod docs

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -57,6 +57,7 @@ type Config struct {
 	SigningKeys map[string]interface{}
 
 	// Signing method used to check the token's signing algorithm.
+	// SigningMethod is not checked when a user-defined KeyFunc is provided.
 	// Optional. Default value HS256.
 	SigningMethod string
 


### PR DESCRIPTION
SigningMethod is not checked when a user-defined KeyFunc is provided. This is explained in the KeyFunc documentation, but we managed to overlook this when configuring echo-jwt.  This commit adds a note to the SigningMethod documentation to help prevent others from making the same mistake.